### PR TITLE
[fix-CVE-2019-10157] update the keycloak package version

### DIFF
--- a/final/stakater-nordmart-web/package.json
+++ b/final/stakater-nordmart-web/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "cors": "^2.8.3",
         "express": "^4.13.4",
-        "keycloak-connect": "^3.1.0",
+        "keycloak-connect": "^4.8.3",
         "request": "^2.74.0"
     },
     "devDependencies": {

--- a/initial/stakater-nordmart-web/package.json
+++ b/initial/stakater-nordmart-web/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "cors": "^2.8.3",
         "express": "^4.13.4",
-        "keycloak-connect": "^3.1.0",
+        "keycloak-connect": "^4.8.3",
         "request": "^2.74.0"
     },
     "devDependencies": {


### PR DESCRIPTION
update the keycloak package version from 3.1.0 to 4.8.3